### PR TITLE
fix(auth): `useRoute()` is not usable here

### DIFF
--- a/@nuxtjs-alt/auth/src/runtime/schemes/openIDConnect.ts
+++ b/@nuxtjs-alt/auth/src/runtime/schemes/openIDConnect.ts
@@ -12,7 +12,7 @@ import {
     Oauth2SchemeEndpoints,
     Oauth2SchemeOptions,
 } from "./oauth2";
-import { useRoute } from "#app";
+// import { useRoute } from "#app";
 
 export interface OpenIDConnectSchemeEndpoints extends Oauth2SchemeEndpoints {
     configuration: string;
@@ -190,7 +190,10 @@ export class OpenIDConnectScheme<OptionsT extends OpenIDConnectSchemeOptions = O
     }
 
     async #handleCallback() {
-        const route = useRoute();
+        // const route = useRoute();
+        /* useRoute() cannot be used here */
+        const route = this.$auth.ctx._route;
+        
         // Handle callback only for specified route
         if (
             this.$auth.options.redirect &&


### PR DESCRIPTION
Would help with the second problem of https://github.com/Teranode/nuxt-module-alternatives/issues/58 but only if https://github.com/Teranode/nuxt-module-alternatives/pull/59 is accepted first.