### PR TITLE
feat(oauth2 options): add organization options to oauth2.ts

### DIFF
--- a/@nuxtjs-alt/auth/src/runtime/schemes/oauth2.ts
+++ b/@nuxtjs-alt/auth/src/runtime/schemes/oauth2.ts
@@ -31,9 +31,10 @@ export interface Oauth2SchemeOptions extends SchemeOptions, TokenableSchemeOptio
     acrValues: string;
     audience: string;
     autoLogout: boolean;
-    clientWindow: boolean
-    clientWindowWidth: number
-    clientWindowHeight: number
+    clientWindow: boolean;
+    clientWindowWidth: number;
+    clientWindowHeight: number;
+    organization?: string;
 }
 
 const DEFAULTS: SchemePartialOptions<Oauth2SchemeOptions> = {
@@ -210,6 +211,10 @@ export class Oauth2Scheme<OptionsT extends Oauth2SchemeOptions = Oauth2SchemeOpt
             clientWindowHeight: this.options.clientWindowHeight,
             ...$opts.params,
         };
+
+        if (this.options.organization) {
+            opts.organization = this.options.organization;
+        }
 
         if (this.options.audience) {
             opts.audience = this.options.audience;


### PR DESCRIPTION
Add Auth0 Organizations support https://auth0.com/docs/manage-users/organizations

As the audience attribute, we can pass an organization ID if we want to log in with an auth0 organization

![image](https://user-images.githubusercontent.com/58557410/197813580-aa45d3ec-8e35-451b-979b-92c66ec4f3c1.png)
